### PR TITLE
fix:モーダルウィンドウのレイアウトを修正

### DIFF
--- a/web/src/app/admin/admin.module.css
+++ b/web/src/app/admin/admin.module.css
@@ -117,7 +117,7 @@
   width: 30px;
   height: 30px;
   padding: 0;
-  border: 1px solid #E0DFDE;
+  border: 1px solid #e0dfde;
   color: #82756a;
 }
 
@@ -135,7 +135,7 @@
 
 .tableContainer {
   width: 100%;
-  border: 1px solid #E0DFDE;
+  border: 1px solid #e0dfde;
 }
 
 .table {
@@ -146,7 +146,7 @@
 .table th,
 .table td {
   height: 60px;
-  border-bottom: 1px solid #E0DFDE;
+  border-bottom: 1px solid #e0dfde;
   font-size: 20px;
   text-align: left;
 }
@@ -203,7 +203,6 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -211,48 +210,58 @@
 }
 
 .modalContent {
-  background-color: white;
-  padding: 30px;
-  border-radius: 8px;
-  width: 90%;
-  max-width: 500px;
   position: relative;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  width: 800px;
+  height: 860px;
+  padding: 80px;
+  border: 1px solid #8b7969;
+  background-color: #fff;
+  box-shadow: 4px 4px 4px rgba(139,121,105, 0.25);
 }
 
 /* モーダル閉じるボタン用のスタイル - Buttonコンポーネントに適用 */
 .modalCloseBtn {
   position: absolute;
-  top: 15px;
-  right: 15px;
-  font-size: 24px;
-  padding: 0;
-  min-width: auto;
-  width: auto;
-  height: auto;
-}
-
-.modalContent h3 {
-  margin-top: 0;
-  margin-bottom: 20px;
-  font-size: 18px;
-  color: #333;
-  font-weight: normal;
-  padding-bottom: 15px;
-  border-bottom: 1px solid #eee;
+  top: 30px;
+  right: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 40px;
+  height: 40px;
+  border: 1px solid #8b7969;
+  border-radius: 50%;
+  font-weight: bold;
 }
 
 .inquiryDetail {
-  margin-top: 15px;
+  margin-top: 30px;
 }
 
 .inquiryDetail p {
-  margin-bottom: 12px;
+  display: flex;
+  width: 650px;
+  height: 40px;
+  padding: 8px 0;
+  margin-bottom: 20px;
   line-height: 1.5;
-  font-size: 14px;
+  font-size: 20px;
 }
 
 .inquiryDetail strong {
+  flex-shrink: 0;
+  margin-right: 50px;
+  width: 180px;
   font-weight: bold;
-  margin-right: 8px;
+}
+
+.buttonContainer {
+  width: 80px;
+  height: 40px;
+  margin: 170px auto 0;
+}
+
+.deleteBtn {
+  width: 100%;
+  height: 100%;
 }

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -197,38 +197,59 @@ export default function Admin() {
             <div className={styles.modalContent}>
               <Button
                 onClick={() => setSelectedInquiry(null)}
-                variant="primary"
-                size="small"
+                variant="close"
+                size="medium"
                 className={styles.modalCloseBtn}
               >
                 ×
               </Button>
-              <h3>お問い合わせ詳細</h3>
               {currentItems
                 .filter((item) => item.id === selectedInquiry)
                 .map((item) => (
                   <div key={item.id} className={styles.inquiryDetail}>
                     <p>
-                      <strong>お名前:</strong> {item.last_name} {item.first_name}
+                      <strong>お名前</strong> {item.last_name} {item.first_name}
                     </p>
                     <p>
-                      <strong>性別:</strong> {item.gender === 1 ? "男性" : item.gender === 2 ? "女性" : "その他"}
+                      <strong>性別</strong> {item.gender === 1 ? "男性" : item.gender === 2 ? "女性" : "その他"}
                     </p>
                     <p>
-                      <strong>メールアドレス:</strong> {item.email}
+                      <strong>メールアドレス</strong> {item.email}
                     </p>
                     <p>
-                      <strong>電話番号:</strong> {item.tell}
+                      <strong>電話番号</strong> {item.tell}
                     </p>
                     <p>
-                      <strong>住所:</strong> {item.address} {item.building}
+                      <strong>住所</strong> {item.address}
                     </p>
                     <p>
-                      <strong>お問い合わせの種類:</strong> {item.category_id === 1 ? "お問い合わせ" : "お申し込み"}
+                      <strong>建物名</strong> {item.building}
                     </p>
                     <p>
-                      <strong>内容:</strong> {item.detail}
+                      <strong>お問い合わせの種類</strong>
+                      {item.category_id === 1
+                        ? "商品のお届けについて"
+                        : item.category_id === 2
+                        ? "商品の交換について"
+                        : item.category_id === 3
+                        ? "商品トラブル"
+                        : item.category_id === 4
+                        ? "ショップへのお問い合わせ"
+                        : "その他"}
                     </p>
+                    <p>
+                      <strong>お問い合わせ内容</strong> {item.detail}
+                    </p>
+                    <div className={styles.buttonContainer}>
+                      <Button
+                        onClick={() => setSelectedInquiry(null)}
+                        variant="delete"
+                        size="medium"
+                        className={styles.deleteBtn}
+                      >
+                        削除
+                      </Button>
+                    </div>
                   </div>
                 ))}
             </div>

--- a/web/src/components/Button/Button.module.css
+++ b/web/src/components/Button/Button.module.css
@@ -71,13 +71,19 @@
 }
 
 .button.variant_close {
-  background: #F4F4F4;
-  color: #333;
+  color: #8B7969;
+  background: #fff;
 }
 
 .button.variant_close:hover:not(:disabled) {
   background: #E0DFDE;
 }
+
+.button.variant_delete {
+  background: #BA370D;
+  color: #fff;
+}
+
 
 /* Sizes */
 .button.size_small {

--- a/web/src/components/Button/Button.tsx
+++ b/web/src/components/Button/Button.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styles from "./Button.module.css";
 
-type ButtonVariant = "primary" | "secondary" | "export" | "pagination" | "detail" | "close";
+type ButtonVariant = "primary" | "secondary" | "export" | "pagination" | "detail" | "close" | "delete";
 type ButtonSize = "small" | "medium" | "large";
 type ButtonDisplay = "inline" | "block" | "inline-flex" | "flex";
 


### PR DESCRIPTION
## 変更目的

- 管理画面の問い合わせ詳細モーダルのレイアウトをデザイン通りに実装

## やったこと

- 詳細モーダルのレイアウトをデザイン仕様に合わせて修正
- 閉じるボタンとUIの調整（ラベル、フォント、余白など）
- 削除ボタンの実装（見た目のみ、クリックで閉じる機能のみ実装）

該当コード:
- `web/src/app/admin/page.tsx`
- `web/src/app/admin/admin.module.css`
- `web/src/components/Button/Button.tsx`
- `web/src/components/Button/Button.module.css`

## 影響範囲

- 管理画面の詳細モーダル表示のみ
- 既存の問い合わせ一覧表示機能には影響なし

## 再現手順

a. 管理画面にアクセス

b. 問い合わせ一覧から「詳細」ボタンをクリック

### 動作確認項目

- モーダルが正しいレイアウトで表示されること
- 閉じるボタン（×）をクリックするとモーダルが閉じること

## 課題 / 質問

- モーダルウィンドウの画面外をクリックしてもモーダルウィンドウを消すことができない

## 備考

- 削除機能は未実装のため、現時点では削除ボタンをクリックしてもデータは削除されません