### PR TITLE
feat:お問い合わせの削除機能作成

### DIFF
--- a/api/app/Http/Controllers/ContactController.php
+++ b/api/app/Http/Controllers/ContactController.php
@@ -12,4 +12,11 @@ class ContactController extends Controller
         $contacts = Contact::all();
         return response()->json($contacts);
     }
+
+    public function destroy($id)
+    {
+        $contact = Contact::findOrFail($id);
+        $contact->delete();
+        return response()->json(['message' => 'お問い合わせを削除しました'], 200);
+    }
 }

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -37,3 +37,4 @@ Route::post('/logout', function (Request $request) {
 })->middleware('auth:sanctum');
 
 Route::get('/contacts', [ContactController::class, 'index']);
+Route::delete('/contacts/{id}', [ContactController::class, 'destroy']);

--- a/web/src/hooks/useSearchForm.ts
+++ b/web/src/hooks/useSearchForm.ts
@@ -1,33 +1,23 @@
 "use client";
 
-import { useState, useEffect, ChangeEvent } from "react";
-import axios from "axios";
+import { useState, ChangeEvent } from "react";
 import { Contact } from "@/types/contact";
 
-export const useSearchForm = () => {
-  const [searchForm, setSearchForm] = useState({
+type SearchFormState = {
+  keyword: string;
+  gender: string;
+  category: string;
+  date: string;
+};
+
+export const useSearchForm = (initialData: Contact[]) => {
+  const [searchForm, setSearchForm] = useState<SearchFormState>({
     keyword: "",
     gender: "",
     category: "",
     date: "",
   });
-  const [contacts, setContacts] = useState<Contact[]>([]);
-  const [filteredData, setFilteredData] = useState<Contact[]>([]);
-
-  // データ取得
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const res = await axios.get("/api/contacts");
-        setContacts(res.data);
-        setFilteredData(res.data);
-      } catch (error) {
-        console.error("エラーが発生しました:", error);
-      }
-    };
-
-    fetchData();
-  }, []);
+  const [filteredData, setFilteredData] = useState<Contact[]>(initialData);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
@@ -37,9 +27,8 @@ export const useSearchForm = () => {
     }));
   };
 
-  // 検索実行
-  const handleSearch = () => {
-    const filtered = contacts.filter((item) => {
+  const handleSearch = (data: Contact[]) => {
+    const filtered = data.filter((item) => {
       const fullName = `${item.last_name}${item.first_name}`;
       const keywordMatch =
         !searchForm.keyword || fullName.includes(searchForm.keyword) || item.email.includes(searchForm.keyword);
@@ -51,25 +40,23 @@ export const useSearchForm = () => {
     });
 
     setFilteredData(filtered);
-    return filtered; // 検索結果を返す
+    return filtered;
   };
 
-  // リセット処理
-  const resetForm = () => {
+  const resetForm = (data: Contact[]) => {
     setSearchForm({
       keyword: "",
       gender: "",
       category: "",
       date: "",
     });
-    setFilteredData(contacts);
-    return contacts; // リセット後のデータを返す
+    setFilteredData(data);
+    return data;
   };
 
   return {
     searchForm,
     handleChange,
-    contacts,
     filteredData,
     handleSearch,
     resetForm,


### PR DESCRIPTION
## 変更概要

- お問い合わせデータの削除機能を実装  
- データ取得と操作の責務を適切に分離し、コードの保守性と再利用性を向上  

---

## 変更内容

### 🔧 バックエンド側の実装

- `ContactController` に `destroy` メソッドを追加
- APIルートに `DELETE /api/contacts/{id}` を追加

### フロントエンド側の実装

- 削除機能の実装  
- 確認ダイアログの表示と削除処理のトリガー  
- 削除成功時の状態更新・モーダルクローズ処理  

### データ取得ロジックの改善

- `useSearchForm` フックからデータ取得の責務を削除 
- ページコンポーネントにデータ取得ロジックを実装 

---

## 影響範囲

- `api/app/Http/Controllers/ContactController.php`  
- `api/routes/api.php`  
- `web/src/hooks/useSearchForm.ts`  
- `web/src/app/admin/page.tsx`  

---

## 再現手順

1. 管理画面にアクセス  
2. 任意のお問い合わせの「詳細」ボタンをクリック  
3. 表示されたモーダル内の「削除」ボタンをクリック  
4. 確認ダイアログで「OK」をクリック  

---

## 動作確認項目

- [ ] 削除ボタンクリック時に確認ダイアログが表示される  
- [ ] 削除成功時に成功メッセージが表示される  
- [ ] 削除後にテーブルデータが更新される  
- [ ] 削除後にモーダルが閉じる  
- [ ] 削除後にページネーションがリセットされる  
- [ ] エラー時にエラーメッセージが表示される  

---

## 課題 / 質問

- 削除後のデータ更新が正しく行われるか  
- エラーハンドリングが適切か  
- CSRFトークンの設定が正しいか  

---

## 備考

- データ取得の責務をページコンポーネントに移動することで、フックの再利用性が向上  
- 削除機能の実装により、お問い合わせデータの管理が可能に  
- エラーハンドリングとユーザーフィードバックを実装し、UXを向上 