### PR TITLE
feat:お問い合わせ入力画面作成

### DIFF
--- a/web/src/app/contact/form/form.module.css
+++ b/web/src/app/contact/form/form.module.css
@@ -1,0 +1,233 @@
+/* =====================
+   全体レイアウト
+   ===================== */
+.container {
+  max-width: 1500px;
+  margin: 0 auto;
+  padding: 0;
+  color: #8b7969;
+}
+
+.title {
+  text-align: center;
+  font-size: 35px;
+  font-weight: normal;
+  margin: 40px 0 30px 0;
+}
+
+/* =====================
+   フォーム本体
+   ===================== */
+.form {
+  width: 970px;
+  height: 610px;
+  margin: 0 auto;
+}
+
+.formGroup {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  height: 40px;
+  margin-bottom: 30px;
+}
+
+.formGroup:nth-child(2) {
+  height: 25px;
+}
+
+.formGroup:last-child {
+  height: 130px;
+  margin-bottom: 0;
+  position: relative;
+}
+
+.label {
+  width: 300px;
+  font-size: 20px;
+  margin-right: 70px;
+  letter-spacing: 0.05em;
+  position: relative;
+}
+
+.label::after {
+  content: "※";
+  color: #ff9494;
+  margin-left: 4px;
+  font-size: 18px;
+}
+
+/* =====================
+   名前入力フォーム
+   ===================== */
+.nameInputs {
+  display: flex;
+  gap: 30px;
+  width: 600px;
+}
+
+/* =====================
+	 性別選択ボタン
+	 ===================== */
+.radioGroup {
+	display: flex;
+	align-items: center;
+	width: 600px;
+	gap: 8px;
+	padding-left: 16px;
+}
+
+.radioGroup input[type="radio"] {
+	appearance: none;
+	width: 20px;
+	height: 20px;
+	padding: 0;
+	border: 1px solid #8b7969;
+	border-radius: 50%;
+	background-color: #fff;
+	position: relative;
+}
+
+.radioGroup input[type="radio"]:checked::after {
+	content: "";
+	position: absolute;
+	top: -1px;
+	left: -1px;
+	width: 20px;
+	height: 20px;
+	background-color: #8b7969;
+	border-radius: 50%;
+}
+
+.radioGroup label {
+	margin-right: 50px;
+	font-size: 18px;
+}
+
+/* =====================
+   メールアドレス、住所、
+	 建物名入力フォーム
+   ===================== */
+
+.formGroup input {
+  width: 600px;
+  height: 40px;
+}
+
+/* =====================
+   電話番号入力フォーム
+   ===================== */
+.tellInputs {
+  display: flex;
+  align-items: center;
+  width: 600px;
+  gap: 20px;
+}
+
+.tellInputs span {
+  font-size: 20px;
+  color: #8b7969;
+}
+
+.tellInputs input {
+  width: 100%;
+}
+
+.tellInputs input::placeholder {
+  padding-left: 40px;
+}
+
+/* =====================
+   セレクト・テキストエリア
+   ===================== */
+.select,
+.textarea {
+  margin-bottom: 0;
+  padding: 12px 18px;
+  background: #f4f4f4;
+  font-size: 14px;
+  color: #BEB1A6;
+}
+
+.select {
+  width: 300px;
+}
+
+.selectWrapper {
+	position: relative;
+}
+
+.selectWrapper::after {
+	content: "";
+	position: absolute;
+	top: 55%;
+	right: 20px;
+	width: 0;
+	height: 0;
+	border-left: 14px solid transparent;
+	border-right: 14px solid transparent;
+	border-top: 16px solid #BEB1A6;
+	transform: translateY(-50%);
+	pointer-events: none;
+}
+
+.textarea {
+  width: 600px;
+  height: 130px;
+	resize: none;
+}
+
+.textarea::placeholder {
+  color: #BEB1A6;
+}
+
+.formGroup:last-child label {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.formGroup:last-child textarea {
+  position: absolute;
+  top: 0;
+  left: 370px;
+}
+
+/* =====================
+   ボタン
+   ===================== */
+.buttonContainer {
+  width: 160px;
+  height: 50px;
+  margin: 50px auto 20px;
+}
+
+.submitButton {
+  width: 100%;
+  height: 100%;
+  padding: 12px 48px;
+  cursor: pointer;
+  letter-spacing: 0.1em;
+  transition: background 0.2s;
+}
+
+.submitButton:hover {
+  background: #a4927b;
+}
+
+/* =====================
+   レスポンシブ
+   ===================== */
+@media (max-width: 1000px) {
+  .form {
+    width: 100%;
+  }
+  .formGroup {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .label {
+    text-align: left;
+    margin-bottom: 8px;
+  }
+}

--- a/web/src/app/contact/form/page.tsx
+++ b/web/src/app/contact/form/page.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useState } from "react";
+import Input from "@/components/Input/Input";
+import Button from "@/components/Button/Button";
+import styles from "./form.module.css";
+
+export default function ContactForm() {
+  const [formData, setFormData] = useState({
+    first_name: "",
+    last_name: "",
+    gender: "",
+    email: "",
+    tell_1: "",
+    tell_2: "",
+    tell_3: "",
+    address: "",
+    building: "",
+    category_id: "",
+    detail: "",
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  return (
+    <div className={styles.container}>
+      <h2 className={styles.title}>Contact</h2>
+      <div className={styles.formContainer}>
+        <form className={styles.form}>
+          <div className={styles.formGroup}>
+            <label htmlFor="first_name" className={styles.label}>
+              お名前
+            </label>
+            <div className={styles.nameInputs}>
+              <Input
+                type="text"
+                id="first_name"
+                name="first_name"
+                value={formData.first_name}
+                placeholder="例：山田"
+                onChange={handleChange}
+              />
+              <Input
+                type="text"
+                id="last_name"
+                name="last_name"
+                value={formData.last_name}
+                placeholder="例：太郎"
+                onChange={handleChange}
+              />
+            </div>
+          </div>
+
+          <div className={styles.formGroup}>
+            <label htmlFor="gender-male" className={styles.label}>
+              性別
+            </label>
+            <div className={styles.radioGroup}>
+              <Input type="radio" id="gender-male" name="gender" value="1" onChange={handleChange} />
+              <label htmlFor="gender-male">男性</label>
+              <Input type="radio" id="gender-female" name="gender" value="2" onChange={handleChange} />
+              <label htmlFor="gender-female">女性</label>
+              <Input type="radio" id="gender-other" name="gender" value="3" onChange={handleChange} />
+              <label htmlFor="gender-other">その他</label>
+            </div>
+          </div>
+
+          <div className={styles.formGroup}>
+            <label htmlFor="email" className={styles.label}>
+              メールアドレス
+            </label>
+            <Input
+              type="email"
+              id="email"
+              name="email"
+              value={formData.email}
+              placeholder="例：test@example.com"
+              onChange={handleChange}
+            />
+          </div>
+
+          <div className={styles.formGroup}>
+            <label htmlFor="tell_1" className={styles.label}>
+              電話番号
+            </label>
+            <div className={styles.tellInputs}>
+              <Input
+                type="tel"
+                id="tell_1"
+                name="tell_1"
+                value={formData.tell_1}
+                placeholder="090"
+                onChange={handleChange}
+              />
+              <span>-</span>
+              <Input
+                type="tel"
+                id="tell_2"
+                name="tell_2"
+                value={formData.tell_2}
+                placeholder="1234"
+                onChange={handleChange}
+              />
+              <span>-</span>
+              <Input
+                type="tel"
+                id="tell_3"
+                name="tell_3"
+                value={formData.tell_3}
+                placeholder="5678"
+                onChange={handleChange}
+              />
+            </div>
+          </div>
+
+          <div className={styles.formGroup}>
+            <label htmlFor="address" className={styles.label}>
+              住所
+            </label>
+            <Input
+              type="text"
+              id="address"
+              name="address"
+              value={formData.address}
+              placeholder="例：東京都渋谷区千駄ヶ谷1-2-3"
+              onChange={handleChange}
+            />
+          </div>
+
+          <div className={styles.formGroup}>
+            <label htmlFor="building" className={styles.label}>
+              建物名
+            </label>
+            <Input
+              type="text"
+              id="building"
+              name="building"
+              value={formData.building}
+              placeholder="例：千駄ヶ谷マンション101"
+              onChange={handleChange}
+            />
+          </div>
+
+          <div className={styles.formGroup}>
+            <label htmlFor="category" className={styles.label}>
+              お問い合わせの種類
+            </label>
+            <div className={styles.selectWrapper}>
+              <select
+                id="category"
+                name="category_id"
+                value={formData.category_id}
+                onChange={handleChange}
+                className={styles.select}
+              >
+                <option value="">選択してください</option>
+                <option value="1">商品のお届けについて</option>
+                <option value="2">商品の交換について</option>
+                <option value="3">商品トラブル</option>
+                <option value="4">ショップへのお問い合わせ</option>
+                <option value="5">その他</option>
+              </select>
+            </div>
+          </div>
+
+          <div className={styles.formGroup}>
+            <label htmlFor="detail" className={styles.label}>
+              お問い合わせ内容
+            </label>
+            <textarea
+              id="detail"
+              name="detail"
+              value={formData.detail}
+              onChange={handleChange}
+              className={styles.textarea}
+              placeholder="お問い合わせ内容をご記載ください"
+            />
+          </div>
+        </form>
+        <div className={styles.buttonContainer}>
+          <Button type="submit" variant="primary" size="medium" className={styles.submitButton}>
+            確認画面へ
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/layout/Header.tsx
+++ b/web/src/app/layout/Header.tsx
@@ -10,6 +10,8 @@ export default function Header() {
   const pathname = usePathname();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
 
+  const hideLogin = pathname.startsWith("/contact");
+
   useEffect(() => {
     // サーバーに認証状態を確認するリクエストを送信
     axios
@@ -62,7 +64,9 @@ export default function Header() {
   return (
     <header className="header">
       <h1 className="header-title">FashionablyLate</h1>
-      <div className="header-links">{renderLink()}</div>
+      {!hideLogin && (
+        <div className="header-links">{renderLink()}</div>
+      )}
     </header>
   );
 }


### PR DESCRIPTION
## 変更概要

- お問い合わせフォーム（入力画面）の新規作成  
- ログインボタンの表示制御（`/contact` 配下では非表示）  

---

## 変更内容

- `/contact/form` ページの新規作成  
- 名前、性別、メールアドレス、電話番号（3分割）、住所、建物名、お問い合わせ種別、お問い合わせ内容の入力欄を実装  
- 入力欄は `Input` コンポーネントを利用し、デザインを統一  
- 電話番号は **3分割入力**  
- セレクトボックスにカスタムデザインを適用（ラッパー＋疑似要素）  
- 必須項目のラベルに「※」を表示  
- レイアウト・スタイルは CSS Modules で管理し、**グループ分け＆コメント追加で保守性を向上**  
- ボタンは `Button` コンポーネントを利用  
- `/contact` 配下の全ページで `Header` のログインボタンを非表示にするロジックを追加  

---

## 影響範囲

- `web/src/app/contact/form/page.tsx`  
- `web/src/app/contact/form/form.module.css`  
- `web/src/app/layout/Header.tsx`（ログインボタンの表示制御）  

---

## 動作確認

- [x] お問い合わせフォームの各項目が正しく表示・入力できる  
- [x] 電話番号は3つの入力欄に分割して入力し、入力欄の間にハイフンを視覚的に表示
- [x] セレクトボックスのカスタム矢印が表示される  
- [x] 必須項目のラベルに「※」が表示される  
- [x] `/contact` 配下のページで `Header` のログインボタンが非表示になる  

---

## 質問

- CSSの可読性、使い方に問題がないか

---

## 備考

- バリデーションや API 連携は今後追加予定  
- 電話番号はフロント側で結合してから送信を行う予定
- デザインやレイアウト(レスポンシブデザインなど)の細かな調整は随時対応可能  
