### PR TITLE
Feature/contact form confirm

### DIFF
--- a/web/src/app/contact/confirm/confirm.module.css
+++ b/web/src/app/contact/confirm/confirm.module.css
@@ -1,0 +1,78 @@
+.container {
+  max-width: 1500px;
+  margin: 0 auto;
+  padding: 0;
+}
+
+.title {
+  text-align: center;
+  font-size: 35px;
+  font-weight: normal;
+  margin: 40px 0 30px 0;
+}
+
+.table {
+  width: 970px;
+  height: 610px;
+  margin: 0 auto;
+  border-collapse: collapse;
+  border: 1px solid #e0dfde;
+}
+
+.tableRow {
+  border-bottom: 1px solid #e0dfde;
+  height: 70px;
+}
+
+.tableRow:last-child {
+  height: 120px;
+}
+
+.tableHeader {
+  width: 300px;
+  padding: 18px 55px;
+  text-align: left;
+  background: #b7a695;
+  color: #fff;
+  font-size: 20px;
+  letter-spacing: 0.05em;
+}
+
+.tableData {
+  padding: 18px 40px;
+  font-size: 20px;
+  letter-spacing: 0.03em;
+}
+
+.firstName {
+  margin-right: 1em;
+}
+
+.buttonGroup {
+  display: flex;
+  justify-content: center;
+  gap: 32px;
+  margin-top: 48px;
+	padding-left: 92px;
+}
+
+.button {
+  width: 120px;
+  height: 42px;
+}
+
+.linkButton {
+  display: inline-block;
+  color: #8c7b6b;
+  background: none;
+  border: none;
+  font-size: 1.1rem;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 8px 16px;
+  transition: color 0.2s;
+}
+
+.linkButton:hover {
+  color: #b7a695;
+}

--- a/web/src/app/contact/confirm/page.tsx
+++ b/web/src/app/contact/confirm/page.tsx
@@ -1,0 +1,60 @@
+import Button from "@/components/Button/Button";
+import Link from "next/link";
+import styles from "./confirm.module.css";
+
+export default function Confirm() {
+  return (
+    <div className={styles.container}>
+      <h2 className={styles.title}>Confirm</h2>
+      <table className={styles.table}>
+        <tbody>
+          <tr className={styles.tableRow}>
+            <th className={styles.tableHeader}>お名前</th>
+            <td className={styles.tableData}>
+              <span className={styles.firstName}>山田</span>
+              <span className={styles.lastName}>太郎</span>
+            </td>
+          </tr>
+          <tr className={styles.tableRow}>
+            <th className={styles.tableHeader}>性別</th>
+            <td className={styles.tableData}>男性</td>
+          </tr>
+          <tr className={styles.tableRow}>
+            <th className={styles.tableHeader}>メールアドレス</th>
+            <td className={styles.tableData}>test@example.com</td>
+          </tr>
+          <tr className={styles.tableRow}>
+            <th className={styles.tableHeader}>電話番号</th>
+            <td className={styles.tableData}>09012345678</td>
+          </tr>
+          <tr className={styles.tableRow}>
+            <th className={styles.tableHeader}>住所</th>
+            <td className={styles.tableData}>東京都千代田区永田町1-7-1</td>
+          </tr>
+          <tr className={styles.tableRow}>
+            <th className={styles.tableHeader}>建物名</th>
+            <td className={styles.tableData}>永田町ビル</td>
+          </tr>
+          <tr className={styles.tableRow}>
+            <th className={styles.tableHeader}>お問い合わせの種類</th>
+            <td className={styles.tableData}>商品の交換について</td>
+          </tr>
+          <tr className={styles.tableRow}>
+            <th className={styles.tableHeader}>お問い合わせ内容</th>
+            <td className={styles.tableData}>
+              届いた商品が注文した商品ではありませんでした。
+              <br />
+              商品の取り替えをお願いします。
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div className={styles.buttonGroup}>
+        <Button className={styles.button}>送信</Button>
+        <Link href="/contact/form" className={styles.linkButton}>
+          修正
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/contact/thanks/page.tsx
+++ b/web/src/app/contact/thanks/page.tsx
@@ -1,0 +1,17 @@
+import styles from "./thanks.module.css";
+import Link from "next/link";
+import Button from "@/components/Button/Button";
+
+export default function Thanks() {
+  return (
+    <div className={styles.container}>
+      <p className={styles.backgroundText}>Thank you</p>
+      <h2 className={styles.title}>お問い合わせありがとうございました。</h2>
+      <Button display="block" className={styles.button}>
+        <Link href="/" className={styles.buttonLink}>
+          HOME
+        </Link>
+      </Button>
+    </div>
+  );
+}

--- a/web/src/app/contact/thanks/thanks.module.css
+++ b/web/src/app/contact/thanks/thanks.module.css
@@ -1,0 +1,39 @@
+.container {
+	position: relative;
+  max-width: 1500px;
+  margin: 0 auto;
+	height: 100vh;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+}
+
+.backgroundText {
+  position: absolute;
+  top: 44%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+	width: 92%;
+  font-size: 280px;
+  color: rgba(139, 121, 105, 0.05);
+  z-index: 0;
+  pointer-events: none;
+  user-select: none;
+}
+
+.title {
+	margin-bottom: 40px;
+  font-size: 30px;
+}
+
+.button {
+	width: 140px;
+	height: 45px;
+}
+
+.buttonLink {
+  text-decoration: none;
+	color: #fff;
+	font-size: 20px;
+}

--- a/web/src/app/layout/Header.tsx
+++ b/web/src/app/layout/Header.tsx
@@ -11,6 +11,7 @@ export default function Header() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
 
   const hideLogin = pathname.startsWith("/contact");
+  const hideHeader = pathname === "/contact/thanks";
 
   useEffect(() => {
     // サーバーに認証状態を確認するリクエストを送信
@@ -62,11 +63,15 @@ export default function Header() {
   };
 
   return (
-    <header className="header">
-      <h1 className="header-title">FashionablyLate</h1>
-      {!hideLogin && (
-        <div className="header-links">{renderLink()}</div>
-      )}
-    </header>
+    <>
+      {!hideHeader &&
+        <header className="header">
+          <h1 className="header-title">FashionablyLate</h1>
+          {!hideLogin && (
+            <div className="header-links">{renderLink()}</div>
+          )}
+        </header>
+      }
+    </>
   );
 }


### PR DESCRIPTION
# 作成した機能名
- お問い合わせ確認画面（Confirmページ）
- お問い合わせ完了画面（Thanksページ）

## 変更目的
- お問い合わせフォームのユーザー体験向上のため、確認画面と完了画面を新規作成
- 入力内容の確認・送信完了の明示により、ユーザーの安心感を高めるため

## 変更内容
- お問い合わせ内容の確認画面（/contact/confirm）の新規作成
  - 入力内容を表形式で表示
  - 「送信」「修正」ボタンを設置
  - レイアウト・配色をデザインに合わせて調整
- お問い合わせ完了画面（/contact/thanks）の新規作成
  - 完了メッセージと背景テキストを表示
  - レイアウト・配色をデザインに合わせて調整
- CSSによるUIデザインの調整（中央寄せ、配色、余白、ボタンデザインなど）

## 影響範囲
- ユーザーへの影響
  - ※現時点では画面のみの実装のため、実際の遷移や送信機能は含まれていません
  - 今後の機能実装時に、今回のUIをもとに接続される予定です
- メンバーへの影響
  - 今後のUI調整やバリデーション追加時は該当ページのCSS・構造に注意
- システムへの影響
  - 既存のお問い合わせ処理には影響なし（新規ページ追加のみ）

## 再現手順
※画面は表示されますが、現時点では遷移や送信処理などの機能は未実装です。

1. `/contact/confirm` に直接アクセスし、確認画面の見た目を確認
2. `/contact/thanks` に直接アクセスし、完了画面の見た目を確認

### 動作確認項目
- [x] レイアウト・配色がデザイン通りである

## 課題・質問
- thanksページのヘッダーを非表示にする方法に不安があるため、レビューをお願いしたい(web/src/app/layout/Header.tsx)

## 🧾 備考
- 2ページ（確認画面・完了画面）を新規作成
- 今回はレイアウトの先行実装となります。動作や画面遷移の実装は今後対応予定です。