### PR TITLE
お問い合わせフォームをセッションに保存して、確認画面に表示

### DIFF
--- a/api/app/Http/Controllers/ContactController.php
+++ b/api/app/Http/Controllers/ContactController.php
@@ -19,4 +19,17 @@ class ContactController extends Controller
         $contact->delete();
         return response()->json(['message' => 'お問い合わせを削除しました'], 200);
     }
+
+    public function tempStore(Request $request)
+    {
+        // requestのデータをセッションに保存して、フロントにレスポンスを返す
+        $request->session()->put('contact', $request->all());
+        return response()->json(['message' => 'お問い合わせを確認しました'], 200);
+    }
+
+    public function sessionData(Request $request)
+    {
+        $contact = $request->session()->get('contact');
+        return response()->json($contact);
+    }
 }

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -38,3 +38,6 @@ Route::post('/logout', function (Request $request) {
 
 Route::get('/contacts', [ContactController::class, 'index']);
 Route::delete('/contacts/{id}', [ContactController::class, 'destroy']);
+
+Route::post('/contact/temp-store', [ContactController::class, 'tempStore']);
+Route::get('/contact/session-data', [ContactController::class, 'sessionData']);

--- a/web/src/app/contact/confirm/page.tsx
+++ b/web/src/app/contact/confirm/page.tsx
@@ -1,8 +1,38 @@
+"use client";
+
 import Button from "@/components/Button/Button";
 import Link from "next/link";
 import styles from "./confirm.module.css";
+import axios from "axios";
+import { useState, useEffect } from "react";
 
 export default function Confirm() {
+  const [confirmData, setConfirmData] = useState({
+    first_name: "",
+    last_name: "",
+    gender: "",
+    email: "",
+    tell: "",
+    address: "",
+    building: "",
+    category_id: "",
+    detail: "",
+  });
+
+  // セッションデータを取得
+  const sessionData = async () => {
+    const response = await axios.get("/api/contact/session-data", { withCredentials: true });
+    return response.data;
+  };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const data = await sessionData();
+      setConfirmData(data);
+    };
+    fetchData();
+  }, []);
+
   return (
     <div className={styles.container}>
       <h2 className={styles.title}>Confirm</h2>
@@ -11,41 +41,39 @@ export default function Confirm() {
           <tr className={styles.tableRow}>
             <th className={styles.tableHeader}>お名前</th>
             <td className={styles.tableData}>
-              <span className={styles.firstName}>山田</span>
-              <span className={styles.lastName}>太郎</span>
+              <span className={styles.firstName}>{confirmData.first_name}</span>
+              <span className={styles.lastName}>{confirmData.last_name}</span>
             </td>
           </tr>
           <tr className={styles.tableRow}>
             <th className={styles.tableHeader}>性別</th>
-            <td className={styles.tableData}>男性</td>
+            <td className={styles.tableData}>
+              {confirmData.gender === "1" ? "男性" : confirmData.gender === "2" ? "女性" : "その他"}
+            </td>
           </tr>
           <tr className={styles.tableRow}>
             <th className={styles.tableHeader}>メールアドレス</th>
-            <td className={styles.tableData}>test@example.com</td>
+            <td className={styles.tableData}>{confirmData.email}</td>
           </tr>
           <tr className={styles.tableRow}>
             <th className={styles.tableHeader}>電話番号</th>
-            <td className={styles.tableData}>09012345678</td>
+            <td className={styles.tableData}>{confirmData.tell}</td>
           </tr>
           <tr className={styles.tableRow}>
             <th className={styles.tableHeader}>住所</th>
-            <td className={styles.tableData}>東京都千代田区永田町1-7-1</td>
+            <td className={styles.tableData}>{confirmData.address}</td>
           </tr>
           <tr className={styles.tableRow}>
             <th className={styles.tableHeader}>建物名</th>
-            <td className={styles.tableData}>永田町ビル</td>
+            <td className={styles.tableData}>{confirmData.building}</td>
           </tr>
           <tr className={styles.tableRow}>
             <th className={styles.tableHeader}>お問い合わせの種類</th>
-            <td className={styles.tableData}>商品の交換について</td>
+            <td className={styles.tableData}>{confirmData.category_id === "1" ? "商品のお届けについて" : confirmData.category_id === "2" ? "商品の交換について" : confirmData.category_id === "3" ? "商品トラブル" : confirmData.category_id === "4" ? "ショップへのお問い合わせ" : "その他"}</td>
           </tr>
           <tr className={styles.tableRow}>
             <th className={styles.tableHeader}>お問い合わせ内容</th>
-            <td className={styles.tableData}>
-              届いた商品が注文した商品ではありませんでした。
-              <br />
-              商品の取り替えをお願いします。
-            </td>
+            <td className={styles.tableData}>{confirmData.detail}</td>
           </tr>
         </tbody>
       </table>

--- a/web/src/app/form.module.css
+++ b/web/src/app/form.module.css
@@ -36,10 +36,22 @@
   height: 25px;
 }
 
-.formGroup:last-child {
+.formGroup:has(textarea) {
   height: 130px;
   margin-bottom: 0;
   position: relative;
+}
+
+.formGroup:has(textarea) label {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.formGroup:has(textarea) textarea {
+  position: absolute;
+  top: 0;
+  left: 370px;
 }
 
 .label {
@@ -70,38 +82,38 @@
 	 性別選択ボタン
 	 ===================== */
 .radioGroup {
-	display: flex;
-	align-items: center;
-	width: 600px;
-	gap: 8px;
-	padding-left: 16px;
+  display: flex;
+  align-items: center;
+  width: 600px;
+  gap: 8px;
+  padding-left: 16px;
 }
 
 .radioGroup input[type="radio"] {
-	appearance: none;
-	width: 20px;
-	height: 20px;
-	padding: 0;
-	border: 1px solid #8b7969;
-	border-radius: 50%;
-	background-color: #fff;
-	position: relative;
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: 1px solid #8b7969;
+  border-radius: 50%;
+  background-color: #fff;
+  position: relative;
 }
 
 .radioGroup input[type="radio"]:checked::after {
-	content: "";
-	position: absolute;
-	top: -1px;
-	left: -1px;
-	width: 20px;
-	height: 20px;
-	background-color: #8b7969;
-	border-radius: 50%;
+  content: "";
+  position: absolute;
+  top: -1px;
+  left: -1px;
+  width: 20px;
+  height: 20px;
+  background-color: #8b7969;
+  border-radius: 50%;
 }
 
 .radioGroup label {
-	margin-right: 50px;
-	font-size: 18px;
+  margin-right: 50px;
+  font-size: 18px;
 }
 
 /* =====================
@@ -146,7 +158,7 @@
   padding: 12px 18px;
   background: #f4f4f4;
   font-size: 14px;
-  color: #BEB1A6;
+  color: #beb1a6;
 }
 
 .select {
@@ -154,43 +166,31 @@
 }
 
 .selectWrapper {
-	position: relative;
+  position: relative;
 }
 
 .selectWrapper::after {
-	content: "";
-	position: absolute;
-	top: 55%;
-	right: 20px;
-	width: 0;
-	height: 0;
-	border-left: 14px solid transparent;
-	border-right: 14px solid transparent;
-	border-top: 16px solid #BEB1A6;
-	transform: translateY(-50%);
-	pointer-events: none;
+  content: "";
+  position: absolute;
+  top: 55%;
+  right: 20px;
+  width: 0;
+  height: 0;
+  border-left: 14px solid transparent;
+  border-right: 14px solid transparent;
+  border-top: 16px solid #beb1a6;
+  transform: translateY(-50%);
+  pointer-events: none;
 }
 
 .textarea {
   width: 600px;
   height: 130px;
-	resize: none;
+  resize: none;
 }
 
 .textarea::placeholder {
-  color: #BEB1A6;
-}
-
-.formGroup:last-child label {
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-
-.formGroup:last-child textarea {
-  position: absolute;
-  top: 0;
-  left: 370px;
+  color: #beb1a6;
 }
 
 /* =====================

--- a/web/src/types/input.ts
+++ b/web/src/types/input.ts
@@ -6,4 +6,5 @@ export type InputProps = {
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   placeholder?: string;
   checked?: boolean;
+  required?: boolean;
 };


### PR DESCRIPTION
# 作成した機能
- お問い合わせ内容をセッションに一時保存
- セッションデータを確認画面に表示

## 変更目的
- フォーム入力体験（UX）の向上
- 対応するIssue[#14 ]

## 変更内容
- フォームデータの型定義を追加
- セッションデータの取得＆表示処理を実装
- UIデザインの微調整
- エラーハンドリングの改善
- ローディング状態の表示機能を追加

## 影響範囲
### ユーザーへの影響
- フォーム入力時のUXが向上
- エラー発生時のフィードバックが明確に表示される
- 送信中はボタンが無効化され、状態がわかりやすくなる

### メンバーへの影響
- 型定義の追加により型安全性が向上
- フォーム構造・状態管理のロジックが一部変更

### システムへの影響
- セッションストレージを使用する処理が追加
- フォームデータの一時保存によるステート管理の導入

## 再現手順
1. フォームに必要事項を入力
2. 「確認画面へ」ボタンをクリック
3. 確認画面でセッションデータが表示される
4. 「修正する」ボタンで元のフォームに戻る

### 動作確認項目
- [ ] フォーム送信後、確認画面に正しく遷移する
- [ ] セッションデータが確認画面に正確に表示される
- [ ] エラー時にメッセージが表示される
- [ ] 送信中はボタンが非活性になる
- [ ] 必須項目が未入力の場合、送信できない
- [ ] 電話番号が正しく分割・結合される

## 課題・質問
- 型宣言がDBのカラム型と一致していない → 修正予定
- エラーメッセージのスタイル未定義 → CSS追加予定
- セッションデータの有効期限の設定が必要 → 要検討

## 備考
- 確認画面の「送信機能」は未実装（今後対応）
- セッションデータは一時保存用途として使用
