### PR TITLE
feat:問い合わせの保存機能作成、お問い合わせフォームの型を修正

### DIFF
--- a/api/app/Http/Controllers/ContactController.php
+++ b/api/app/Http/Controllers/ContactController.php
@@ -22,7 +22,6 @@ class ContactController extends Controller
 
     public function tempStore(Request $request)
     {
-        // requestのデータをセッションに保存して、フロントにレスポンスを返す
         $request->session()->put('contact', $request->all());
         return response()->json(['message' => 'お問い合わせを確認しました'], 200);
     }
@@ -31,5 +30,12 @@ class ContactController extends Controller
     {
         $contact = $request->session()->get('contact');
         return response()->json($contact);
+    }
+
+    public function contactStore(Request $request)
+    {
+        $contact = Contact::create($request->all());
+        $request->session()->forget('contact');
+        return response()->json(['message' => 'お問い合わせを受け付けました'], 200);
     }
 }

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -32,7 +32,6 @@ Route::post('/logout', function (Request $request) {
     $request->session()->invalidate();       // セッションを無効にする
     $request->session()->regenerateToken();  // CSRFトークンを再生成（セキュリティ対策）
 
-    // $request->user()->tokens()->delete();
     return response()->json(['message' => 'ログアウトしました。']);
 })->middleware('auth:sanctum');
 
@@ -41,3 +40,4 @@ Route::delete('/contacts/{id}', [ContactController::class, 'destroy']);
 
 Route::post('/contact/temp-store', [ContactController::class, 'tempStore']);
 Route::get('/contact/session-data', [ContactController::class, 'sessionData']);
+Route::post('/contact/contact-store', [ContactController::class, 'contactStore']);

--- a/web/src/app/contact/confirm/page.tsx
+++ b/web/src/app/contact/confirm/page.tsx
@@ -5,9 +5,12 @@ import Link from "next/link";
 import styles from "./confirm.module.css";
 import axios from "axios";
 import { useState, useEffect } from "react";
+import { ConfirmData } from "@/types/contact";
+import { useRouter } from "next/navigation";
 
 export default function Confirm() {
-  const [confirmData, setConfirmData] = useState({
+  const router = useRouter();
+  const [confirmData, setConfirmData] = useState<ConfirmData>({
     first_name: "",
     last_name: "",
     gender: "",
@@ -15,7 +18,7 @@ export default function Confirm() {
     tell: "",
     address: "",
     building: "",
-    category_id: "",
+    category_id: 0,
     detail: "",
   });
 
@@ -32,6 +35,29 @@ export default function Confirm() {
     };
     fetchData();
   }, []);
+
+  // データを送信する関数
+  const handleSubmit = async () => {
+    try {
+      // 性別を数値型に変換
+      const submitData = {
+        ...confirmData,
+        gender: parseInt(confirmData.gender),
+      };
+
+      const response = await axios.post("/api/contact/contact-store", submitData, {
+        withCredentials: true,
+      });
+
+      if (response.status === 200) {
+        // 送信成功時の処理
+        router.push("/contact/thanks");
+      }
+    } catch (error) {
+      console.error("送信エラー:", error);
+      alert("送信に失敗しました。もう一度お試しください。");
+    }
+  };
 
   return (
     <div className={styles.container}>
@@ -69,7 +95,17 @@ export default function Confirm() {
           </tr>
           <tr className={styles.tableRow}>
             <th className={styles.tableHeader}>お問い合わせの種類</th>
-            <td className={styles.tableData}>{confirmData.category_id === "1" ? "商品のお届けについて" : confirmData.category_id === "2" ? "商品の交換について" : confirmData.category_id === "3" ? "商品トラブル" : confirmData.category_id === "4" ? "ショップへのお問い合わせ" : "その他"}</td>
+            <td className={styles.tableData}>
+              {confirmData.category_id === 1
+                ? "商品のお届けについて"
+                : confirmData.category_id === 2
+                ? "商品の交換について"
+                : confirmData.category_id === 3
+                ? "商品トラブル"
+                : confirmData.category_id === 4
+                ? "ショップへのお問い合わせ"
+                : "その他"}
+            </td>
           </tr>
           <tr className={styles.tableRow}>
             <th className={styles.tableHeader}>お問い合わせ内容</th>
@@ -78,7 +114,9 @@ export default function Confirm() {
         </tbody>
       </table>
       <div className={styles.buttonGroup}>
-        <Button className={styles.button}>送信</Button>
+        <Button className={styles.button} onClick={handleSubmit}>
+          送信
+        </Button>
         <Link href="/" className={styles.linkButton}>
           修正
         </Link>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -6,20 +6,7 @@ import Button from "@/components/Button/Button";
 import styles from "./form.module.css";
 import axios from "axios";
 import { useRouter } from "next/navigation";
-
-type FormData = {
-  first_name: string;
-  last_name: string;
-  gender: string;
-  email: string;
-  tell_1: string;
-  tell_2: string;
-  tell_3: string;
-  address: string;
-  building: string;
-  category_id: number;
-  detail: string;
-};
+import { FormData } from "@/types/contact";
 
 const initialFormData: FormData = {
   first_name: "",

--- a/web/src/types/contact.ts
+++ b/web/src/types/contact.ts
@@ -1,12 +1,23 @@
-export type Contact = {
-  id: number;
-  category_id: number;
+// 共通部分
+export type BaseContact = {
   first_name: string;
   last_name: string;
-  gender: number;
+  gender: string;
   email: string;
-  tell: string;
   address: string;
   building: string;
+  category_id: number;
   detail: string;
+};
+
+// フォーム入力用
+export type FormData = BaseContact & {
+  tell_1: string;
+  tell_2: string;
+  tell_3: string;
+};
+
+// 確認画面用
+export type ConfirmData = BaseContact & {
+  tell: string;
 };


### PR DESCRIPTION
# 作成した機能名
- お問い合わせ保存機能
- お問い合わせの型を修正

## 変更目的
- お問い合わせの保存を行えるように作成
- 電話番号の結合前後で型指定を出来るよう修正
- 対応するIssue（[#14 ]）

## 変更内容
端的に記述します：
- UIデザインの調整
- APIのレスポンス構造の変更
- バリデーションの追加 など

## 影響範囲
### ユーザーへの影響
- 確認画面からthanksページへの遷移が追加される
### メンバーへの影響
- お問い合わせデータがデータベースに保存される
- セッションデータが送信後に削除される
### システムへの影響
- バックエンドのバリデーション実装が必要（今後の課題）

## 再現手順
1. `/contact` ページにアクセス
2. フォームを入力し確認ページに遷移
3. 確認ページからデータを送信後の挙動を確認

### 動作確認項目
- [ ] 確認ページからthanksページに遷移する
- [ ] thanksページのホームボタンからお問い合わせフォームに遷移する

## 課題・質問
- バリデーションをバックエンド側で行っていない（修正予定）
