### PR TITLE
fix:モーダルの外側クリックで閉じられない問題と、姓名の逆表示を修正

### DIFF
--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -76,6 +76,13 @@ export default function Admin() {
     setSelectedInquiry(id);
   };
 
+  // モーダルを非表示にする
+  const handleModalClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      setSelectedInquiry(null);
+    }
+  };
+
   // エクスポート機能
   const handleExport = () => {
     console.log("エクスポート機能が呼び出されました");
@@ -238,7 +245,7 @@ export default function Admin() {
 
         {/* 詳細モーダル */}
         {selectedInquiry && (
-          <div className={styles.modal}>
+          <div className={styles.modal} onClick={handleModalClick}>
             <div className={styles.modalContent}>
               <Button
                 onClick={() => setSelectedInquiry(null)}
@@ -253,7 +260,7 @@ export default function Admin() {
                 .map((item) => (
                   <div key={item.id} className={styles.inquiryDetail}>
                     <p>
-                      <strong>お名前</strong> {item.last_name} {item.first_name}
+                      <strong>お名前</strong> {item.first_name} {item.last_name}
                     </p>
                     <p>
                       <strong>性別</strong> {item.gender === 1 ? "男性" : item.gender === 2 ? "女性" : "その他"}


### PR DESCRIPTION
# 修正した機能
- モーダルの外側をクリックして閉じられるように修正
- モーダルに表示されている姓名が逆になっていたのを修正

## 変更目的
- UXの向上
- 表示ミスの修正のため

## 変更内容
- UIデザインの調整

## 影響範囲
### ユーザーへの影響
- モーダルウィンドウを閉じる手段が増える

## 再現手順
1. `/contact/admin` ページにアクセス
2. お問い合わせの詳細ボタンをクリック
3. モーダルウィンドウの外側をクリック

### 動作確認項目
- [ ] 氏名が正しく表示されている
- [ ] モーダルウィンドウが正常に閉じられる
